### PR TITLE
Needs Triton CNS label for Consul so that MySQL can connect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ consul:
     command: -server -bootstrap -ui-dir /ui
     restart: always
     mem_limit: 128m
+    labels:
+      - triton.cns.services=consul
     ports:
       - 8500
     dns:


### PR DESCRIPTION
@misterbisson although CNS is not used in this blueprint, if we want to make this application available as a starting point to add other blueprints like MySQL, we at least need Consul to have a CNS name.
