### PR TITLE
change consul query to get healthy nodes only

### DIFF
--- a/customers/customers.js
+++ b/customers/customers.js
@@ -23,7 +23,7 @@ var getUpstreams = function(force, callback) {
         http.get({
             host: 'consul',
             port: 8500,
-            path: '/v1/catalog/service/sales'
+            path: '/v1/health/service/sales?passing'
         }, function(response) {
             var body = '';
             response.on('data', function(d) { body += d; });
@@ -31,8 +31,8 @@ var getUpstreams = function(force, callback) {
                 var parsed = JSON.parse(body);
                 hosts = []
                 for (var i = 0; i < parsed.length; i++) {
-                    hosts.push({address: parsed[i].ServiceAddress,
-                                port: parsed[i].ServicePort});
+                    hosts.push({address: parsed[i].Service.Address,
+                                port: parsed[i].Service.Port});
                 }
                 upstreamHosts = hosts; // cache the result
                 callback(hosts);


### PR DESCRIPTION
Currently, the workshop example queries Consul for all registered services.  This will bring back unhealthy services, as well as healthy services, which is not desired.  To query Consul for a list of healthy services only, the path should hit /v1/health/service/... and ask for 'passing' services only.

For instance:
`
        http.get({
            host: 'consul',
            port: 8500,
            path: '/v1/health/service/sales?passing'
        }
`

Thanks to @dsapala for identifying this.
