### PR TITLE
Consul query to /health/ endpoint to get healthy nodes only

### DIFF
--- a/customers/customers.js
+++ b/customers/customers.js
@@ -23,7 +23,7 @@ var getUpstreams = function(force, callback) {
         http.get({
             host: 'consul',
             port: 8500,
-            path: '/v1/catalog/service/sales'
+            path: '/v1/health/service/sales?passing'
         }, function(response) {
             var body = '';
             response.on('data', function(d) { body += d; });
@@ -31,8 +31,8 @@ var getUpstreams = function(force, callback) {
                 var parsed = JSON.parse(body);
                 hosts = []
                 for (var i = 0; i < parsed.length; i++) {
-                    hosts.push({address: parsed[i].ServiceAddress,
-                                port: parsed[i].ServicePort});
+                    hosts.push({address: parsed[i].Service.Address,
+                                port: parsed[i].Service.Port});
                 }
                 upstreamHosts = hosts; // cache the result
                 callback(hosts);

--- a/sales/consul.js
+++ b/sales/consul.js
@@ -6,7 +6,7 @@ exports.getUpstreams = function(service, callback) {
   http.get({
     host: 'consul',
     port: 8500,
-    path: '/v1/catalog/service/' + service
+    path: '/v1/health/service/' + service + '?passing'
   }, function(response) {
     var body = '';
     response.on('data', function(d) { body += d; });
@@ -14,8 +14,8 @@ exports.getUpstreams = function(service, callback) {
       var parsed = JSON.parse(body);
       hosts = []
       for (var i = 0; i < parsed.length; i++) {
-        hosts.push({address: parsed[i].ServiceAddress,
-                    port: parsed[i].ServicePort});
+        hosts.push({address: parsed[i].Service.Address,
+                    port: parsed[i].Service.Port});
       }
       callback(hosts);
     });


### PR DESCRIPTION
per @ttrahan:

> Currently, the workshop example queries Consul for all registered services.
> This will bring back unhealthy services, as well as healthy services, which is
> not desired. To query Consul for a list of healthy services only, the path
> should hit /v1/health/service/... and ask for 'passing' services only.

This commit includes the code in https://github.com/autopilotpattern/workshop/pull/10 but adds the change to the sales app too. The branch that commit was made on has been marked as "unknown" by GitHub so this PR is to get both changes in.

cc @misterbisson 
