### PR TITLE
nodeenv in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.pyc
+venv/

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,6 @@ help:
 	@echo "'make ship' to docker push"
 
 
-#ifeq ($(DOCKER_CERT_PATH),)
-#	DOCKER_CTX := -v /var/run/docker.sock:/var/run/docker.sock
-#else
-#	DOCKER_CTX := -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=$(DOCKER_CERT_PATH:$(HOME)%=%) -e DOCKER_HOST=$(DOCKER_HOST)
-#endif
-
 build:
 	docker-compose -f local-compose.yml build
 	docker tag workshop_nginx autopilotpattern/workshop-nginx

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-# temporary Makefile for use while figuring out the test rig
+NODE_VERSION=6.0.0
+JSON_VERSION=9.0.3
+NODEENV_VERSION=0.13.6
+TRITON_VERSION=4.11.0
 DOCKER_CERT_PATH ?=
 DOCKER_HOST ?=
 DOCKER_TLS_VERIFY ?=
@@ -6,10 +9,28 @@ LOG_LEVEL ?= INFO
 SDC_ACCOUNT ?=
 
 ifeq ($(DOCKER_CERT_PATH),)
-	DOCKER_CTX := -v /var/run/docker.sock:/var/run/docker.sock
+        DOCKER_CTX := -v /var/run/docker.sock:/var/run/docker.sock
 else
-	DOCKER_CTX := -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=$(DOCKER_CERT_PATH:$(HOME)%=%) -e DOCKER_HOST=$(DOCKER_HOST)
+        DOCKER_CTX := -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=$(DOCKER_CERT_PATH:$(HOME)%=%) -e DOCKER_HOST=$(DOCKER_HOST)
 endif
+
+help:
+	@echo "'make localnode' builds and activates a local nodejs ${NODE_VERSION} environment"
+	@echo "under venv/ directory."
+	@echo
+	@echo "'source venv/bin/activate' to activate the virtualenv"
+	@echo "'deactivate' to disable the virtualenv"
+	@echo "'make clean' to destroy virtualenv"
+	@echo
+	@echo "'make build' to build docker environment"
+	@echo "'make ship' to docker push"
+
+
+#ifeq ($(DOCKER_CERT_PATH),)
+#	DOCKER_CTX := -v /var/run/docker.sock:/var/run/docker.sock
+#else
+#	DOCKER_CTX := -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=$(DOCKER_CERT_PATH:$(HOME)%=%) -e DOCKER_HOST=$(DOCKER_HOST)
+#endif
 
 build:
 	docker-compose -f local-compose.yml build
@@ -49,3 +70,28 @@ shell:
 		-e LOG_LEVEL=$(LOG_LEVEL) \
 		-v $(shell pwd):/src \
 		-w /src test python
+
+localnode: venv/bin/json venv/bin/triton
+	@echo
+	@echo
+	@echo "'source venv/bin/activate' to activate the virtualenv"
+	@echo "'deactivate' to disable the virtualenv"
+	@echo
+
+clean:
+	rm -rf venv
+
+venv:
+	virtualenv venv
+
+venv/bin/nodeenv: | venv
+	venv/bin/pip install nodeenv==${NODEENV_VERSION}
+
+venv/bin/node: | venv/bin/nodeenv
+	venv/bin/nodeenv --prebuilt -p -n ${NODE_VERSION}
+
+venv/bin/json: | venv/bin/node
+	. venv/bin/activate; venv/bin/npm install -g json@${JSON_VERSION}
+
+venv/bin/triton: | venv/bin/node
+	. venv/bin/activate; venv/bin/npm install -g triton@${TRITON_VERSION}


### PR DESCRIPTION
nodeenv allows a Python virtualenv to contain a complete nodejs and npm installation. This addition to the Makefile builds a node virtualenv with 'make localnode'. It is destroyed with 'make clean'.
